### PR TITLE
ISAPP-101: removed /is and /parser prefixed from urls

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -111,8 +111,8 @@ CACHES = {
 
 # static
 
-BASE_STATIC_URL = 'api/parser/static/'
-STATIC_URL = 'is/' + BASE_STATIC_URL
+BASE_STATIC_URL = 'api/static/'
+STATIC_URL = BASE_STATIC_URL
 STATIC_ROOT = BASE_DIR + 'static'
 
 # swagger

--- a/api/urls.py
+++ b/api/urls.py
@@ -6,10 +6,9 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 urlpatterns = []
 
 urlpatterns += [
-    path('is/api/parser/__docs__/', SpectacularAPIView.as_view(), name='__docs__'),
-    path('api/parser/__docs__/', SpectacularAPIView.as_view()),
-    path('api/parser/', SpectacularSwaggerView.as_view(url_name='__docs__')),
-    path('api/parser/lessons/', include('app.lessons.urls')),
-    path('api/parser/employees/', include('app.employees.urls')),
+    path('api/__docs__/', SpectacularAPIView.as_view(), name='__docs__'),
+    path('api/', SpectacularSwaggerView.as_view(url_name='__docs__')),
+    path('api/lessons/', include('app.lessons.urls')),
+    path('api/employees/', include('app.employees.urls')),
     *static(settings.BASE_STATIC_URL, document_root=settings.STATIC_ROOT),
 ]


### PR DESCRIPTION
ISAPP-101: removed /is and /parser prefixed from urls